### PR TITLE
Add FastAPI edit endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import openai
+import os
+
+app = FastAPI()
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+class EditRequest(BaseModel):
+    title: str
+    date: str
+    body: str
+    link: str
+
+@app.post("/edit")
+async def edit(req: EditRequest):
+    prompt = (
+        "Rewrite the following news body in a casual Gen Z WhatsApp style. "
+        "Respond with just the rewritten text.\n\n" + req.body
+    )
+    try:
+        resp = openai.ChatCompletion.create(
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=0.7,
+        )
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    new_body = resp.choices[0].message.content.strip()
+    formatted = (
+        "\U0001F985 Loud Hawk News\n"
+        f"\U0001F4E2 *{req.title}*\n"
+        f"\U0001F4C5 {req.date}\n"
+        f"{new_body}\n"
+        f"\U0001F517 [Read more]({req.link})"
+    )
+    return {"text": formatted}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+openai
+pydantic


### PR DESCRIPTION
## Summary
- implement `/edit` FastAPI route that rewrites body text via OpenAI
- add basic project dependencies

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854e7f99288832ea8e8035bfb514b44