### PR TITLE
Switch to async ChatCompletion

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ async def edit(req: EditRequest):
         "Respond with just the rewritten text.\n\n" + req.body
     )
     try:
-        resp = openai.ChatCompletion.create(
+        resp = await openai.ChatCompletion.acreate(
             model="gpt-4",
             messages=[{"role": "user", "content": prompt}],
             temperature=0.7,


### PR DESCRIPTION
## Summary
- use async `openai.ChatCompletion.acreate` in `/edit` endpoint

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6854ea6885d4832ea8276ebf89499362