### PR TITLE
Ensure OPENAI_API_KEY is required

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,14 @@ import os
 
 app = FastAPI()
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+api_key = os.getenv("OPENAI_API_KEY")
+if not api_key:
+    raise RuntimeError(
+        "OPENAI_API_KEY environment variable not set. "
+        "Please add it to your .env file or environment."
+    )
+
+openai.api_key = api_key
 
 class EditRequest(BaseModel):
     title: str


### PR DESCRIPTION
## Summary
- validate `OPENAI_API_KEY` at startup and provide guidance when missing

## Testing
- `python -m py_compile app/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6854ea85cfc0832ead915a288b04f3c1