### PR TITLE
Add edit endpoint test

### DIFF
--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import types
+import pytest
+from starlette.testclient import TestClient
+
+# Provide a stub openai module if it's not installed
+openai = types.ModuleType("openai")
+
+class ChatCompletion:
+    async def acreate(*args, **kwargs):
+        raise NotImplementedError
+
+openai.ChatCompletion = ChatCompletion
+openai.api_key = None
+sys.modules["openai"] = openai
+
+# Ensure API key is set before importing the app
+os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+from app.main import app
+import openai  # type: ignore  # noqa: E402
+
+
+def test_edit_returns_formatted(monkeypatch):
+    async def fake_acreate(*args, **kwargs):
+        class DummyMessage:
+            content = "Mocked body"
+
+        class DummyChoice:
+            message = DummyMessage()
+
+        class DummyResp:
+            choices = [DummyChoice()]
+
+        return DummyResp()
+
+    monkeypatch.setattr(openai.ChatCompletion, "acreate", fake_acreate)
+
+    payload = {
+        "title": "Breaking News",
+        "date": "2023-08-01",
+        "body": "Some news body.",
+        "link": "https://example.com",
+    }
+
+    expected = (
+        "\U0001F985 Loud Hawk News\n"
+        "\U0001F4E2 *Breaking News*\n"
+        "\U0001F4C5 2023-08-01\n"
+        "Mocked body\n"
+        "\U0001F517 [Read more](https://example.com)"
+    )
+
+    with TestClient(app) as client:
+        response = client.post("/edit", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == {"text": expected}


### PR DESCRIPTION
## Summary
- add a pytest test for the `/edit` endpoint using `starlette.testclient`
- mock the OpenAI API call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'starlette')*

------
https://chatgpt.com/codex/tasks/task_e_6854eb39fce4832e85c52968065c574b